### PR TITLE
[V-2] Handle DEBUG macros better

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(GNUInstallDirs)
 set(CLIENT_MX CACHE STRING "Client email server address")
 set(CLIENT_EMAIL CACHE STRING "Client (sender) email address")
 set(CATCH_ALL_LOCAL_PART CACHE STRING "A dummy local part to test if catch-all is enabled")
-option(PRINT_RESPONSE "Print the request response" OFF)
+option(DEBUG "Use debug features" OFF)
 
 foreach (PARAM CLIENT_MX CLIENT_EMAIL CATCH_ALL_LOCAL_PART)
     if (${PARAM} STREQUAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ include(GNUInstallDirs)
 set(CLIENT_MX CACHE STRING "Client email server address")
 set(CLIENT_EMAIL CACHE STRING "Client (sender) email address")
 set(CATCH_ALL_LOCAL_PART CACHE STRING "A dummy local part to test if catch-all is enabled")
-option(DEBUG "Use debug features" OFF)
 
 foreach (PARAM CLIENT_MX CLIENT_EMAIL CATCH_ALL_LOCAL_PART)
     if (${PARAM} STREQUAL "")

--- a/config.h.in
+++ b/config.h.in
@@ -1,4 +1,4 @@
 #cmakedefine CLIENT_MX "@CLIENT_MX@"
 #cmakedefine CLIENT_EMAIL "@CLIENT_EMAIL@"
 #cmakedefine CATCH_ALL_LOCAL_PART "@CATCH_ALL_LOCAL_PART@"
-#cmakedefine01 DEBUG_RESPONSE
+#cmakedefine01 DEBUG

--- a/config.h.in
+++ b/config.h.in
@@ -1,4 +1,3 @@
 #cmakedefine CLIENT_MX "@CLIENT_MX@"
 #cmakedefine CLIENT_EMAIL "@CLIENT_EMAIL@"
 #cmakedefine CATCH_ALL_LOCAL_PART "@CATCH_ALL_LOCAL_PART@"
-#cmakedefine01 DEBUG

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -48,7 +48,7 @@ send_command(int sock, char *format, ...)
     }
 
     if (verbose) printf("REQUEST: %s", command);
-    
+
     if (send(sock, command, strlen(command), 0) < 0) {
         return VRF_ERR;
     }
@@ -284,8 +284,8 @@ main(int argc, char **argv)
             case 'e':
                 result->email = strdup(optarg);
                 if (!result->email) {
-                    return EXIT_FAILURE;
                     free_vrf(result);
+                    return EXIT_FAILURE;
                 }
 
                 emailflag = true;

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -267,9 +267,11 @@ main(int argc, char **argv)
 
     if(argc < 2) {
         printf("No options provided.\n");
+        return EXIT_FAILURE;
     }
     else {
         printf("Options provided\n");
+        return EXIT_SUCCESS;
     }
 
     char *email = NULL;

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -265,6 +265,10 @@ main(int argc, char **argv)
     extern char *optarg;
     extern int optind;
 
+    if(argc < 2) {
+        printf("No options provided.");
+    }
+
     char *email = NULL;
     bool emailflag = false;
     bool verboseflag = 0;

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -266,7 +266,10 @@ main(int argc, char **argv)
     extern int optind;
 
     if(argc < 2) {
-        printf("No options provided.");
+        printf("No options provided.\n");
+    }
+    else {
+        printf("Options provided\n");
     }
 
     char *email = NULL;

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -19,6 +19,12 @@
 #define FREE(p) free(p); p = NULL;
 #endif
 
+#ifdef DEBUG
+    #define DEBUG_PRINT(...) printf(__VA_ARGS__)
+#else
+    #define DEBUG_PRINT
+#endif
+
 #define CHECK_OK(f, err)    \
 if ((err = f) != VRF_OK) {  \
     return err;             \
@@ -44,9 +50,9 @@ send_command(int sock, char *format, ...)
     if (vasprintf(&command, format, args) < 0) {
         return VRF_ERR;
     }
-#if DEBUG_RESPONSE
-    printf("REQUEST: %s", command);
-#endif
+
+    DEBUG_PRINT("REQUEST: %s", command);
+    
     if (send(sock, command, strlen(command), 0) < 0) {
         return VRF_ERR;
     }
@@ -66,9 +72,7 @@ read_response(int sock, char *buffer)
         return VRF_ERR;
     }
 
-    #if DEBUG_RESPONSE
-        printf("RESPONSE: %s", (char *) b);
-    #endif
+    DEBUG_PRINT("RESPONSE: %s", (char *) b);
 
 //    memset(*b, 0, nbytes);
     return VRF_OK;
@@ -143,9 +147,8 @@ check_mx(char *email, struct addrinfo *adrrinfo, VRF *result)
         printf("Connection failed.\n");
         return VRF_ERR;
     }
-    #if DEBUG_RESPONSE
-        printf("SUCCESSFULLY CONNECTED TO %s\n", (*result)->mx_record);
-    #endif
+    
+    DEBUG_PRINT("SUCCESSFULLY CONNECTED TO %s\n", (*result)->mx_record);
 
     int err;
     CHECK_OK(read_response(sock, buffer), err)

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -19,7 +19,7 @@
 #define FREE(p) free(p); p = NULL;
 #endif
 
-#ifdef DEBUG
+#if DEBUG == 1
     #define DEBUG_PRINT(...) printf(__VA_ARGS__)
 #else
     #define DEBUG_PRINT
@@ -147,7 +147,7 @@ check_mx(char *email, struct addrinfo *adrrinfo, VRF *result)
         printf("Connection failed.\n");
         return VRF_ERR;
     }
-    
+
     DEBUG_PRINT("SUCCESSFULLY CONNECTED TO %s\n", (*result)->mx_record);
 
     int err;

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -269,10 +269,6 @@ main(int argc, char **argv)
         printf("No options provided.\n");
         return EXIT_FAILURE;
     }
-    else {
-        printf("Options provided\n");
-        return EXIT_SUCCESS;
-    }
 
     char *email = NULL;
     bool emailflag = false;

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -299,7 +299,7 @@ main(int argc, char **argv)
 
     verbose = verboseflag;
 
-    if (emailflag)
+    if (!emailflag)
     {
         fprintf(stderr, "-e flag is required.\n");
         free_vrf(result);

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -279,7 +279,7 @@ main(int argc, char **argv)
     if (errno) return EXIT_FAILURE;
 
     int c;
-    while ((c = getopt(argc, argv, "e:v"))) {
+    while ((c = getopt(argc, argv, "e:v")) != -1) {
         switch(c) {
             case 'e':
                 result->email = strdup(optarg);

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -266,7 +266,7 @@ main(int argc, char **argv)
     extern int optind;
 
     if(argc < 2) {
-        printf("No options provided.\n");
+        fprintf(stderr, "Usage: %s [OPTIONS].\n", argv[0]);
         return EXIT_FAILURE;
     }
 
@@ -283,7 +283,6 @@ main(int argc, char **argv)
         switch(c) {
             case 'e':
                 result->email = strdup(optarg);
-                printf("Result email: %s", result->email);
                 if (!result->email) {
                     return EXIT_FAILURE;
                     free_vrf(result);

--- a/src/vrf.c
+++ b/src/vrf.c
@@ -262,11 +262,6 @@ verify(VRF *result)
 int
 main(int argc, char **argv)
 {
-    if (argc < 2) {
-        printf("Usage: vrf -e <email>\n");
-        return EXIT_FAILURE;
-    }
-
     extern char *optarg;
     extern int optind;
 
@@ -279,10 +274,11 @@ main(int argc, char **argv)
     if (errno) return EXIT_FAILURE;
 
     int c;
-    while ((c = getopt(argc, argv, "ev"))) {
+    while ((c = getopt(argc, argv, "e:v"))) {
         switch(c) {
             case 'e':
                 result->email = strdup(optarg);
+                printf("Result email: %s", result->email);
                 if (!result->email) {
                     return EXIT_FAILURE;
                     free_vrf(result);


### PR DESCRIPTION
Done in PR:
- Changed option name to be called `DEBUG` instead of `DEBUG_RESPONSE`
- Changed all the usages of `DEBUG_RESPONSE` to be `DEBUG_PRINT`