### PR TITLE
[V-3] Add `c-ares` library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ dkms.conf
 
 **/*build*/
 *.idea/
+.cache
+CMakeCache.txt
+CMakeFiles
+cmake/CPM.cmake
+cpm-package-lock.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,9 @@ configure_file(config.h.in config.h @ONLY)
 add_library(${PROJECT_NAME} ${HEADERS} ${SOURCES})
 
 CPMAddPackage("gh:fmtlib/fmt#10.2.1")
+CPMAddPackage("gh:c-ares/c-ares@1.30.0")
 
-set(DEPENDENCIES "fmt")
+set(DEPENDENCIES "fmt" "c-ares")
 if (WIN32)
     list(APPEND DEPENDENCIES "ws2_32" "dnsapi")
 else ()

--- a/cmake/project.cmake
+++ b/cmake/project.cmake
@@ -4,6 +4,7 @@ set(PROJECT_DESCRIPTION "Email Verification")
 set(PROJECT_VERSION 0.0.3.0)
 set(CMAKE_PROJECT_HOMEPAGE_URL https://tuposoft.com)
 set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 file(
         DOWNLOAD


### PR DESCRIPTION
This PR introduces the integration of the `c-ares` library, a C library for asynchronous DNS requests, including MX record lookups. This change is designed to replace the current manual process, which relies on multiple system calls, with a more streamlined and efficient approach.

Key 
- `Asynchronous Execution`: By leveraging c-ares, we can perform non-blocking DNS queries, which is essential for maintaining the responsiveness of our application.
- `Simplified Codebase`: The c-ares library abstracts the complexity of DNS protocols, resulting in cleaner and more maintainable code.
- `Scalability`: As our application grows, the ability to handle DNS queries asynchronously will be crucial in scaling our services without compromising performance.
- `Future-Proofing`: Adopting c-ares prepares our system for future enhancements, including the potential for more complex DNS operations.

This enhancement is a step towards modernizing our DNS handling capabilities, ensuring that our system remains robust and agile in the face of evolving network demands.

I’ve focused on emphasizing the benefits of using the c-ares library for DNS queries and the positive impact it will have on the application’s performance and maintainability. The description is now more detailed, highlighting the strategic reasons behind the integration and its advantages.